### PR TITLE
Removing header_request_params config

### DIFF
--- a/src/test/java/com/google/api/codegen/gapic/testdata/csharp/csharp_library.baseline
+++ b/src/test/java/com/google/api/codegen/gapic/testdata/csharp/csharp_library.baseline
@@ -11418,8 +11418,7 @@ namespace Google.Example.Library.V1
             _callMergeShelves = clientHelper.BuildApiCall<MergeShelvesRequest, Shelf>(
                 GrpcClient.MergeShelvesAsync, GrpcClient.MergeShelves, effectiveSettings.MergeShelvesSettings);
             _callCreateBook = clientHelper.BuildApiCall<CreateBookRequest, Book>(
-                GrpcClient.CreateBookAsync, GrpcClient.CreateBook, effectiveSettings.CreateBookSettings)
-                .WithCallSettingsOverlay(request => gaxgrpc::CallSettings.FromHeader("x-goog-request-params", $"name={request.Name}&book.read={request.Book.Read}"));
+                GrpcClient.CreateBookAsync, GrpcClient.CreateBook, effectiveSettings.CreateBookSettings);
             _callPublishSeries = clientHelper.BuildApiCall<PublishSeriesRequest, PublishSeriesResponse>(
                 GrpcClient.PublishSeriesAsync, GrpcClient.PublishSeries, effectiveSettings.PublishSeriesSettings);
             _callGetBook = clientHelper.BuildApiCall<GetBookRequest, Book>(

--- a/src/test/java/com/google/api/codegen/gapic/testdata/go/go_library.baseline
+++ b/src/test/java/com/google/api/codegen/gapic/testdata/go/go_library.baseline
@@ -184,7 +184,6 @@ package library
 
 import (
     "context"
-    "fmt"
     "math"
     "time"
 
@@ -477,8 +476,7 @@ func (c *LibClient) MergeShelves(ctx context.Context, req *librarypb.MergeShelve
 
 // CreateBook creates a book.
 func (c *LibClient) CreateBook(ctx context.Context, req *librarypb.CreateBookRequest, opts ...gax.CallOption) (*librarypb.Book, error) {
-    md := metadata.Pairs("x-goog-request-params", fmt.Sprintf("%s=%v&%s=%v", "name", req.GetName(), "book.read", req.GetBook().GetRead()))
-    ctx = insertMetadata(ctx, c.xGoogMetadata, md)
+    ctx = insertMetadata(ctx, c.xGoogMetadata)
     opts = append(c.CallOptions.CreateBook[0:len(c.CallOptions.CreateBook):len(c.CallOptions.CreateBook)], opts...)
     var resp *librarypb.Book
     err := gax.Invoke(ctx, func(ctx context.Context, settings gax.CallSettings) error {

--- a/src/test/java/com/google/api/codegen/gapic/testdata/java/java_library.baseline
+++ b/src/test/java/com/google/api/codegen/gapic/testdata/java/java_library.baseline
@@ -5361,16 +5361,6 @@ public class GrpcLibraryServiceStub extends LibraryServiceStub {
     GrpcCallSettings<CreateBookRequest, Book> createBookTransportSettings =
         GrpcCallSettings.<CreateBookRequest, Book>newBuilder()
             .setMethodDescriptor(createBookMethodDescriptor)
-            .setParamsExtractor(
-                new RequestParamsExtractor<CreateBookRequest>() {
-                  @Override
-                  public Map<String, String> extract(CreateBookRequest request) {
-                    ImmutableMap.Builder<String, String> params = ImmutableMap.builder();
-                    params.put("name", String.valueOf(request.getName()));
-                    params.put("book.read", String.valueOf(request.getBook().getRead()));
-                    return params.build();
-                  }
-                })
             .build();
     GrpcCallSettings<PublishSeriesRequest, PublishSeriesResponse> publishSeriesTransportSettings =
         GrpcCallSettings.<PublishSeriesRequest, PublishSeriesResponse>newBuilder()

--- a/src/test/java/com/google/api/codegen/gapic/testdata/nodejs/nodejs_library.baseline
+++ b/src/test/java/com/google/api/codegen/gapic/testdata/nodejs/nodejs_library.baseline
@@ -3836,12 +3836,6 @@ class LibraryServiceClient {
       options = {};
     }
     options = options || {};
-    options.otherArgs = options.otherArgs || {};
-    options.otherArgs.headers = options.otherArgs.headers || {};
-    options.otherArgs.headers['x-goog-request-params'] =
-      gax.routingHeader.fromParams({
-        'name': request.name, 'book.read': request.book.read
-      });
 
     return this._innerApiCalls.createBook(request, options, callback);
   }

--- a/src/test/java/com/google/api/codegen/gapic/testdata/php/php_library.baseline
+++ b/src/test/java/com/google/api/codegen/gapic/testdata/php/php_library.baseline
@@ -781,14 +781,6 @@ class LibraryServiceGapicClient
         $request->setName($name);
         $request->setBook($book);
 
-        $requestParams = new RequestParamsHeaderDescriptor([
-          'name' => $request->getName(),
-          'book.read' => $request->getBook()->getRead(),
-        ]);
-        $optionalArgs['headers'] = isset($optionalArgs['headers'])
-            ? array_merge($requestParams->getHeader(), $optionalArgs['headers'])
-            : $requestParams->getHeader();
-
         return $this->startCall(
             'CreateBook',
             Book::class,

--- a/src/test/java/com/google/api/codegen/gapic/testdata/py/python_library.baseline
+++ b/src/test/java/com/google/api/codegen/gapic/testdata/py/python_library.baseline
@@ -1022,7 +1022,6 @@ from google.oauth2 import service_account
 import google.api_core.gapic_v1.client_info
 import google.api_core.gapic_v1.config
 import google.api_core.gapic_v1.method
-import google.api_core.gapic_v1.routing_header
 import google.api_core.grpc_helpers
 import google.api_core.operation
 import google.api_core.operations_v1
@@ -1604,17 +1603,6 @@ class LibraryServiceClient(object):
             name=name,
             book=book,
         )
-        if metadata is None:
-            metadata = []
-        metadata = list(metadata)
-        try:
-            routing_header = [('name', name), ('book.read', book.read)]
-        except AttributeError:
-            pass
-        else:
-            routing_metadata = google.api_core.gapic_v1.routing_header.to_grpc_metadata(routing_header)
-            metadata.append(routing_metadata)
-
         return self._inner_api_calls['create_book'](request, retry=retry, timeout=timeout, metadata=metadata)
 
     def publish_series(

--- a/src/test/java/com/google/api/codegen/gapic/testdata/ruby/ruby_library.baseline
+++ b/src/test/java/com/google/api/codegen/gapic/testdata/ruby/ruby_library.baseline
@@ -3011,10 +3011,7 @@ module Library
         @create_book = Google::Gax.create_api_call(
           @library_service_stub.method(:create_book),
           defaults["create_book"],
-          exception_transformer: exception_transformer,
-          params_extractor: proc do |request|
-            {'name' => request.name, 'book.read' => request.book.read}
-          end
+          exception_transformer: exception_transformer
         )
         @publish_series = Google::Gax.create_api_call(
           @library_service_stub.method(:publish_series),

--- a/src/test/java/com/google/api/codegen/testsrc/libraryproto/library_gapic.yaml
+++ b/src/test/java/com/google/api/codegen/testsrc/libraryproto/library_gapic.yaml
@@ -192,9 +192,6 @@ interfaces:
     resource_name_treatment: NONE
     field_name_patterns:
       name: shelf
-    header_request_params:
-    - name
-    - book.read
   - name: PublishSeries
     flattening:
       groups:


### PR DESCRIPTION
What happens when we remove the `header_request_params` config value from GAPIC config?